### PR TITLE
Refactor: Simplify image utils to use clipboard-based paste

### DIFF
--- a/.cursor/rules/python.mdc
+++ b/.cursor/rules/python.mdc
@@ -1,0 +1,12 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Package Management
+- Use the uv package manager
+- Do not track a requirements.txt file, instead use the builtin uv files
+- Use "uv add" to add packages
+- Use "uv remove" to remove unneeded packages when refactoring code
+    - Only use this if the package is no longer used globally
+    - 

--- a/snippingtool/image_utils.py
+++ b/snippingtool/image_utils.py
@@ -1,26 +1,10 @@
-import pyautogui
 import time
 from PIL import Image
 import platform
-import os
-import tempfile
 import subprocess
-from typing import Tuple, Optional
-
-def save_image_to_temp(image: Image.Image) -> str:
-    """
-    Saves a PIL Image to a temporary file and returns the path.
-    
-    Args:
-        image (PIL.Image): The image to save
-        
-    Returns:
-        str: Path to the temporary file
-    """
-    with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp_file:
-        temp_path = temp_file.name
-        image.save(temp_path, 'PNG')
-    return temp_path
+from typing import Optional
+import pyperclipimg
+from pynput.keyboard import Key, Controller as KeyboardController
 
 def get_chrome_path() -> str:
     """
@@ -45,108 +29,43 @@ def open_browser(url: str) -> None:
     """
     chrome_path = get_chrome_path()
     subprocess.Popen([chrome_path, '--new-window', url])
-    time.sleep(3)  # Wait for window to load
-
-def get_screen_center() -> Tuple[int, int]:
-    """
-    Calculates the center coordinates of the screen.
-    
-    Returns:
-        Tuple[int, int]: (x, y) coordinates of screen center
-    """
-    screen_width, screen_height = pyautogui.size()
-    return (screen_width // 2, screen_height // 2)
-
-def find_and_select_file_macos(file_path: str) -> None:
-    """
-    Uses Spotlight to find and select a file on macOS.
-    
-    Args:
-        file_path (str): Path to the file to find
-    """
-    pyautogui.hotkey('command', 'space')
-    time.sleep(1)
-    pyautogui.write(file_path)
-    time.sleep(1)
-    pyautogui.press('enter')
-    time.sleep(2)
-
-def find_and_select_file_windows(file_path: str) -> None:
-    """
-    Opens file location and selects file on Windows/Linux.
-    
-    Args:
-        file_path (str): Path to the file to find
-    """
-    os.startfile(os.path.dirname(file_path))
-    time.sleep(2)
-    pyautogui.click()
-    time.sleep(0.5)
-
-def drag_to_center(center_x: int, center_y: int) -> None:
-    """
-    Performs drag and drop operation to the specified center coordinates.
-    
-    Args:
-        center_x (int): X coordinate of center
-        center_y (int): Y coordinate of center
-    """
-    pyautogui.mouseDown()
-    time.sleep(0.5)
-    pyautogui.moveTo(center_x, center_y, duration=0.5)
-    pyautogui.mouseUp()
-
-def cleanup_temp_file(file_path: str) -> None:
-    """
-    Safely removes a temporary file.
-    
-    Args:
-        file_path (str): Path to the file to remove
-    """
-    try:
-        os.unlink(file_path)
-    except Exception as e:
-        print(f"Warning: Could not remove temporary file: {str(e)}")
 
 def open_chatgpt_and_drop_image(image: Image.Image) -> bool:
     """
-    Opens ChatGPT in a new Chrome window and drags/drops the given image to the center.
+    Opens ChatGPT in a new Chrome window and pastes the given image using clipboard.
     
     Args:
-        image (PIL.Image): The image to be dragged and dropped
+        image (PIL.Image): The image to be pasted
         
     Returns:
         bool: True if operation was successful, False otherwise
     """
-    temp_path: Optional[str] = None
+    keyboard = KeyboardController()
     
     try:
-        # Save image to temp file
-        temp_path = save_image_to_temp(image)
+        # Save image to clipboard
+        pyperclipimg.copy(image)
         
-        # Open browser and get screen center
+        # Open browser
         open_browser("https://chat.openai.com")
-        center_x, center_y = get_screen_center()
+        time.sleep(1)  # Wait for page to load
         
-        # Find and select file based on OS
-        if platform.system() == "Darwin":
-            find_and_select_file_macos(temp_path)
-        else:
-            find_and_select_file_windows(temp_path)
+        # Paste image directly using pyperclip
+        keyboard.press(Key.cmd)
+        keyboard.press('v')
+        keyboard.release('v')
+        keyboard.release(Key.cmd)
+        time.sleep(1)  # Wait for paste to complete
         
-        # Perform drag and drop
-        drag_to_center(center_x, center_y)
+        # Press enter to send
+        keyboard.press(Key.enter)
+        keyboard.release(Key.enter)
         
         return True
         
     except Exception as e:
-        print(f"Error during drag and drop operation: {str(e)}")
+        print(f"Error during paste operation: {str(e)}")
         return False
-        
-    finally:
-        # Clean up temp file if it was created
-        if temp_path:
-            cleanup_temp_file(temp_path)
 
 if __name__ == "__main__":
     # Example usage

--- a/snippingtool/pyproject.toml
+++ b/snippingtool/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "pillow>=11.2.1",
     "pyautogui>=0.9.54",
     "pynput>=1.8.1",
+    "pyobjc-framework-quartz>=11.0",
+    "pyperclip>=1.9.0",
+    "pyperclipimg>=0.2.0",
     "python-dotenv>=1.1.0",
-    "rumps>=0.4.0",
 ]

--- a/snippingtool/uv.lock
+++ b/snippingtool/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 1
 requires-python = ">=3.11"
+resolution-markers = [
+    "sys_platform == 'linux'",
+    "sys_platform == 'win32'",
+    "sys_platform == 'darwin'",
+    "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -384,10 +390,10 @@ name = "pyobjc-framework-applicationservices"
 version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coretext" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coretext", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ba/fb/4e42573b0d3baa3fa18ec53614cf979f951313f1451e8f2e17df9429da1f/pyobjc_framework_applicationservices-11.0.tar.gz", hash = "sha256:d6ea18dfc7d5626a3ecf4ac72d510405c0d3a648ca38cae8db841acdebecf4d2", size = 224334 }
 wheels = [
@@ -417,9 +423,9 @@ name = "pyobjc-framework-coretext"
 version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/9b68dc788828e38143a3e834e66346713751cb83d7f0955016323005c1a2/pyobjc_framework_coretext-11.0.tar.gz", hash = "sha256:a68437153e627847e3898754dd3f13ae0cb852246b016a91f9c9cbccb9f91a43", size = 274222 }
 wheels = [
@@ -450,6 +456,17 @@ name = "pyperclip"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/23/2f0a3efc4d6a32f3b63cdff36cd398d9701d26cda58e3ab97ac79fb5e60d/pyperclip-1.9.0.tar.gz", hash = "sha256:b7de0142ddc81bfc5c7507eea19da920b92252b548b96186caf94a5e2527d310", size = 20961 }
+
+[[package]]
+name = "pyperclipimg"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/85/5afb0c0007fed16e581ef97d2ff44a4633dba6609b584256a88657ca6f3c/pyperclipimg-0.2.0.tar.gz", hash = "sha256:7934402ed7ce898e0a3b659e8cafb7c6a2faf7f9ad00069a0fe15a077aae1239", size = 5365 }
 
 [[package]]
 name = "pyrect"
@@ -500,6 +517,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/0c/c16bc93ac2755bac0066a8ecbd2a2931a1735a6fffd99a2b9681c7e83e90/pytweening-1.2.0.tar.gz", hash = "sha256:243318b7736698066c5f362ec5c2b6434ecf4297c3c8e7caa8abfe6af4cac71b", size = 171241 }
 
 [[package]]
+name = "pywin32"
+version = "310"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/b1/68aa2986129fb1011dabbe95f0136f44509afaf072b12b8f815905a39f33/pywin32-310-cp311-cp311-win32.whl", hash = "sha256:1e765f9564e83011a63321bb9d27ec456a0ed90d3732c4b2e312b855365ed8bd", size = 8784284 },
+    { url = "https://files.pythonhosted.org/packages/b3/bd/d1592635992dd8db5bb8ace0551bc3a769de1ac8850200cfa517e72739fb/pywin32-310-cp311-cp311-win_amd64.whl", hash = "sha256:126298077a9d7c95c53823934f000599f66ec9296b09167810eb24875f32689c", size = 9520748 },
+    { url = "https://files.pythonhosted.org/packages/90/b1/ac8b1ffce6603849eb45a91cf126c0fa5431f186c2e768bf56889c46f51c/pywin32-310-cp311-cp311-win_arm64.whl", hash = "sha256:19ec5fc9b1d51c4350be7bb00760ffce46e6c95eaf2f0b2f1150657b1a43c582", size = 8455941 },
+    { url = "https://files.pythonhosted.org/packages/6b/ec/4fdbe47932f671d6e348474ea35ed94227fb5df56a7c30cbbb42cd396ed0/pywin32-310-cp312-cp312-win32.whl", hash = "sha256:8a75a5cc3893e83a108c05d82198880704c44bbaee4d06e442e471d3c9ea4f3d", size = 8796239 },
+    { url = "https://files.pythonhosted.org/packages/e3/e5/b0627f8bb84e06991bea89ad8153a9e50ace40b2e1195d68e9dff6b03d0f/pywin32-310-cp312-cp312-win_amd64.whl", hash = "sha256:bf5c397c9a9a19a6f62f3fb821fbf36cac08f03770056711f765ec1503972060", size = 9503839 },
+    { url = "https://files.pythonhosted.org/packages/1f/32/9ccf53748df72301a89713936645a664ec001abd35ecc8578beda593d37d/pywin32-310-cp312-cp312-win_arm64.whl", hash = "sha256:2349cc906eae872d0663d4d6290d13b90621eaf78964bb1578632ff20e152966", size = 8459470 },
+    { url = "https://files.pythonhosted.org/packages/1c/09/9c1b978ffc4ae53999e89c19c77ba882d9fce476729f23ef55211ea1c034/pywin32-310-cp313-cp313-win32.whl", hash = "sha256:5d241a659c496ada3253cd01cfaa779b048e90ce4b2b38cd44168ad555ce74ab", size = 8794384 },
+    { url = "https://files.pythonhosted.org/packages/45/3c/b4640f740ffebadd5d34df35fecba0e1cfef8fde9f3e594df91c28ad9b50/pywin32-310-cp313-cp313-win_amd64.whl", hash = "sha256:667827eb3a90208ddbdcc9e860c81bde63a135710e21e4cb3348968e4bd5249e", size = 9503039 },
+    { url = "https://files.pythonhosted.org/packages/b4/f4/f785020090fb050e7fb6d34b780f2231f302609dc964672f72bfaeb59a28/pywin32-310-cp313-cp313-win_arm64.whl", hash = "sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33", size = 8458152 },
+]
+
+[[package]]
 name = "rubicon-objc"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -507,15 +540,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/d3/13/586c9baa985eae0f7
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/30/5b2407b8762ed882e5732e19c485b9ea2f07d35462615a3212638bab66c2/rubicon_objc-0.5.0-py3-none-any.whl", hash = "sha256:a9c2a605120d6e5be327d3f42a71b60963125987e116f51846757b5e110854fa", size = 62711 },
 ]
-
-[[package]]
-name = "rumps"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyobjc-framework-cocoa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/e2/2e6a47951290bd1a2831dcc50aec4b25d104c0cf00e8b7868cbd29cf3bfe/rumps-0.4.0.tar.gz", hash = "sha256:17fb33c21b54b1e25db0d71d1d793dc19dc3c0b7d8c79dc6d833d0cffc8b1596", size = 39257 }
 
 [[package]]
 name = "six"
@@ -544,8 +568,10 @@ dependencies = [
     { name = "pillow" },
     { name = "pyautogui" },
     { name = "pynput" },
+    { name = "pyobjc-framework-quartz" },
+    { name = "pyperclip" },
+    { name = "pyperclipimg" },
     { name = "python-dotenv" },
-    { name = "rumps" },
 ]
 
 [package.metadata]
@@ -554,8 +580,10 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "pyautogui", specifier = ">=0.9.54" },
     { name = "pynput", specifier = ">=1.8.1" },
+    { name = "pyobjc-framework-quartz", specifier = ">=11.0" },
+    { name = "pyperclip", specifier = ">=1.9.0" },
+    { name = "pyperclipimg", specifier = ">=0.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
-    { name = "rumps", specifier = ">=0.4.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR simplifies the image handling code by:\n\n- Replacing drag-and-drop with clipboard-based paste\n- Using pyperclipimg for reliable image clipboard operations\n- Removing unused functions and simplifying the codebase\n- Improving reliability of image pasting into ChatGPT